### PR TITLE
Commands fixes

### DIFF
--- a/bm2ebm.php
+++ b/bm2ebm.php
@@ -16,7 +16,7 @@ function parseline( $line, $key, $open, $close ){
 }
 
 $category="IMPORT";
-newCat( $category );
+newCat( $category, $ebm_user );
 $filename=$_FILES['bookmarks']['tmp_name'];
 $data=file($filename);
 $stack=array();

--- a/commands.php
+++ b/commands.php
@@ -65,7 +65,7 @@ function db_exec( $SQL, $param=array() ){
  **/
 function db_initDB(){
     echo "<h1>Could not open db?!</h1>";
-return;
+//return;
     $cid = db_openDB();
 	$cid->beginTransaction();
     $res = $cid->exec( "CREATE TABLE users ( name VARCHAR(16) UNIQUE, password CHAR(32) );" );


### PR DESCRIPTION
Found two small but important bugs during my installation.

The first only strikes when you have no tables in your sqlite db (which on a new install would be everyone, of course).  The second didn't hit until I loaded a large bookmark file, not sure why - my first round test was like 10 bookmarks and it had no trouble.

In any case, both fixes are now in my self-hosted instance and seem to work well.

Regards,
Brant
